### PR TITLE
Fix to compile with PennMUSH 1.8.8 and GCC 10

### DIFF
--- a/hdrs/space.h
+++ b/hdrs/space.h
@@ -310,6 +310,15 @@ struct spaceconfig {
 	double cochrane_rate;
 };
 
+ #if __GNUC_PREREQ(10,0)
+extern intmap *border_map;
+
+extern HASHTAB aspace_consoles;
+#else
+intmap *border_map;
+HASHTAB aspace_consoles;
+#endif
+
 typedef struct spaceconfig SPACETAB;
 extern SPACETAB configstruct;
 
@@ -320,10 +329,6 @@ struct aspace_empire_info {
 	double y;
 	double z;
 };
-
-intmap *border_map;
-
-HASHTAB aspace_consoles;
 
 typedef struct _space_consoles {
 	char *console_name;

--- a/src/space_set.c
+++ b/src/space_set.c
@@ -3,7 +3,7 @@
 #include "config.h"
 #include "space.h"
 
-struct db_stat_info current_state;
+struct db_stat_info aspace_current_state;
 
 /*----------------------------------------------------------------------------*/
 


### PR DESCRIPTION
PennMUSH 1.8.8 has a conflicting current_state definition which prevents ASpace from compiling. Renaming ASpaces definition to aspace_current_state fixes this issue.

GCC 10 changes the behaviour of global variables to require the extern keyword in the header file and causes linker errors if untreated. Since we have various versions still in use this has been tackled with a preprocessor macro.